### PR TITLE
Add Nature Credits page and Freyra color

### DIFF
--- a/src/assets/theme/base/colors.js
+++ b/src/assets/theme/base/colors.js
@@ -84,6 +84,11 @@ const colors = {
     focus: "#344767",
   },
 
+  freyraGreen: {
+    main: "#2BC48A",
+    focus: "#66A182",
+  },
+
   grey: {
     100: "#f8f9fa",
     200: "#e9ecef",

--- a/src/layouts/nature-credits/index.js
+++ b/src/layouts/nature-credits/index.js
@@ -1,0 +1,21 @@
+import SoftBox from "components/SoftBox";
+import SoftTypography from "components/SoftTypography";
+import DashboardLayout from "examples/LayoutContainers/DashboardLayout";
+import DashboardNavbar from "examples/Navbars/DashboardNavbar";
+import Footer from "examples/Footer";
+
+function NatureCredits() {
+  return (
+    <DashboardLayout>
+      <DashboardNavbar />
+      <SoftBox py={3}>
+        <SoftTypography variant="h3">
+          Velkommen til Nature Credits markedspladsen
+        </SoftTypography>
+      </SoftBox>
+      <Footer />
+    </DashboardLayout>
+  );
+}
+
+export default NatureCredits;

--- a/src/routes.js
+++ b/src/routes.js
@@ -44,6 +44,7 @@ import RTL from "layouts/rtl";
 import Profile from "layouts/profile";
 import SignIn from "layouts/authentication/sign-in";
 import SignUp from "layouts/authentication/sign-up";
+import NatureCredits from "layouts/nature-credits";
 
 // Soft UI Dashboard React icons
 import Shop from "examples/Icons/Shop";
@@ -54,6 +55,7 @@ import SpaceShip from "examples/Icons/SpaceShip";
 import CustomerSupport from "examples/Icons/CustomerSupport";
 import CreditCard from "examples/Icons/CreditCard";
 import Cube from "examples/Icons/Cube";
+import Icon from "@mui/material/Icon";
 
 const routes = [
   {
@@ -63,6 +65,15 @@ const routes = [
     route: "/dashboard",
     icon: <Shop size="12px" />,
     component: <Dashboard />,
+    noCollapse: true,
+  },
+  {
+    type: "collapse",
+    name: "Nature Credits",
+    key: "nature-credits",
+    route: "/nature-credits",
+    icon: <Icon fontSize="small">eco</Icon>,
+    component: <NatureCredits />,
     noCollapse: true,
   },
   {


### PR DESCRIPTION
## Summary
- add Freyra green color to theme
- create new `Nature Credits` page
- expose the page via routes with an eco icon

## Testing
- `npm test --silent` *(fails: react-scripts not found)*