### PR TITLE
Fix SoftButton color prop

### DIFF
--- a/src/components/SoftButton/index.js
+++ b/src/components/SoftButton/index.js
@@ -26,7 +26,7 @@ const SoftButton = forwardRef(
     <SoftButtonRoot
       {...rest}
       ref={ref}
-      color="primary"
+      color={color}
       variant={variant === "gradient" ? "contained" : variant}
       size={size}
       ownerState={{ color, variant, size, circular, iconOnly }}


### PR DESCRIPTION
## Summary
- pass the `color` prop to `SoftButtonRoot` so buttons receive the correct color

## Testing
- `npm test` *(fails: react-scripts not found)*