### PR TITLE
Fix Netlify build install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,14 @@ Quick start options:
 To deploy this project on [Netlify](https://www.netlify.com/):
 
 1. Create a new site from Git and select your repository.
-2. Set **Build command** to `npm run build`.
+2. Set **Build command** to `npm run install:peer-deps && npm run build`.
 3. Set **Publish directory** to `build`.
 
 You can keep these settings in a `netlify.toml` file at the project root:
 
 ```toml
 [build]
-  command = "npm run build"
+  command = "npm run install:peer-deps && npm run build"
   publish = "build"
 ```
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,6 @@
 [build]
-  command = "npm run build"
+  # Install dependencies with legacy peer dep handling then build
+  command = "npm run install:peer-deps && npm run build"
   publish = "build"
 
 [build.environment]


### PR DESCRIPTION
## Summary
- install peer dependencies before build on Netlify
- document new build command in README

## Testing
- `npm --version`
- `node --version`
